### PR TITLE
boss/3ds: Add support for multiple payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,16 +136,17 @@ type CTRBOSSContainer = {
 ```
 
 ### CTRCryptoOptions
-Passed in when encrypting 3DS contents. `program_id` and `title_id` are aliases, one must be set
+Passed in when encrypting 3DS contents. `program_id` and `title_id` are aliases, one must be set. `release_date` is only needed when calling `encrypt`. `path_or_buffer` is only needed when calling `encrypt3DS`.
 
 ```ts
 type CTRCryptoOptions = {
 	program_id?: string | number | bigint;
 	title_id?: string | number | bigint;
-	release_date: bigint;
+	release_date?: bigint;
 	content_datatype: number;
 	ns_data_id: number;
 	version: number;
+	path_or_buffer?: string | Buffer;
 }
 ```
 
@@ -240,15 +241,15 @@ Takes in encrypted BOSS used for the 3DS data and decrypts it. This function is 
 
 ### Signature
 ```ts
-function encrypt3DS(pathOrBuffer: string | Buffer, aesKey: string | Buffer, options: CTRCryptoOptions): Buffer
+function encrypt3DS(aesKey: string | Buffer, serialNumber: bigint, options: CTRCryptoOptions[]): Buffer
 ```
 
-Takes in content and encrypts it for the 3DS using the provided options
+Takes in multiple contents and encrypts them for the 3DS using the provided options and serial number
 
 ### Arguments
-- `pathOrBuffer`: Either a string path to the file or a buffer containing the raw data
 - `aesKey`: BOSS AES encryption key
-- `options`: `CTRCryptoOptions`
+- `serialNumber`: Serial number used in the BOSS container
+- `options`: Array of `CTRCryptoOptions`
 
 ### Returns:
 3DS encrypted BOSS data

--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ import { encrypt3DS } from '@pretendonetwork/boss-crypto';
 const { BOSS_AES_KEY } = process.env;
 
 const content = Buffer.from('Hello World');
-const encrypted = encrypt3DS(content, BOSS_3DS_AES_KEY, {
+const encrypted = encrypt3DS(BOSS_3DS_AES_KEY, 1692231927n, {
 	program_id: 0x0004001000022900, // can also be named "title_id"
 	content_datatype: 65537,
-	release_date: 1692231927n,
 	ns_data_id: 36,
+	version: 1,
+	path_or_buffer: content,
 });
 
 fs.writeFileSync(__dirname + '/hello-world.boss', encrypted);

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const encrypted = encrypt3DS(BOSS_3DS_AES_KEY, 1692231927n, {
 	content_datatype: 65537,
 	ns_data_id: 36,
 	version: 1,
-	path_or_buffer: content,
+	content,
 });
 
 fs.writeFileSync(__dirname + '/hello-world.boss', encrypted);
@@ -137,7 +137,7 @@ type CTRBOSSContainer = {
 ```
 
 ### CTRCryptoOptions
-Passed in when encrypting 3DS contents. `program_id` and `title_id` are aliases, one must be set. `release_date` is only needed when calling `encrypt`. `path_or_buffer` is only needed when calling `encrypt3DS`.
+Passed in when encrypting 3DS contents. `program_id` and `title_id` are aliases, one must be set. `release_date` is only needed when calling `encrypt`. `content` is only needed when calling `encrypt3DS`.
 
 ```ts
 type CTRCryptoOptions = {
@@ -147,7 +147,7 @@ type CTRCryptoOptions = {
 	content_datatype: number;
 	ns_data_id: number;
 	version: number;
-	path_or_buffer?: string | Buffer;
+	content?: string | Buffer;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ const { BOSS_AES_KEY } = process.env;
 
 const encryptedFilePath = __dirname + '/EU_BGM1';
 
-const { content } = decrypt3DS(encryptedFilePath, BOSS_AES_KEY);
+const { payload_contents } = decrypt3DS(encryptedFilePath, BOSS_AES_KEY);
 
-fs.writeFileSync(__dirname + '/EU_BGM1.dec', content);
+fs.writeFileSync(__dirname + '/EU_BGM1.dec', payload_contents[0].content);
 ```
 
 # API
@@ -106,6 +106,21 @@ type WUPBOSSInfo = {
 }
 ```
 
+### CTRPayloadContent
+Holds the contents of one of the payloads of a 3DS BOSS container
+
+```ts
+type CTRPayloadContent = {
+	payload_content_header_hash: Buffer;
+	payload_content_header_hash_signature: Buffer;
+	program_id: bigint;
+	content_datatype: number;
+	ns_data_id: number;
+	version: number;
+	content: Buffer;
+}
+```
+
 ### CTRBOSSContainer
 Returned when decrypting 3DS BOSS content. Contains all relevant data from the real BOSS container. See https://www.3dbrew.org/wiki/SpotPass#Content_Container for more details
 
@@ -116,17 +131,11 @@ type CTRBOSSContainer = {
 	iv: Buffer;
 	content_header_hash: Buffer;
 	content_header_hash_signature: Buffer;
-	payload_content_header_hash: Buffer;
-	payload_content_header_hash_signature: Buffer;
-	program_id: bigint;
-	content_datatype: number;
-	ns_data_id: number;
-	content: Buffer;
+	payload_contents: CTRPayloadContent[];
 }
 ```
 
 ### CTRCryptoOptions
-
 Passed in when encrypting 3DS contents. `program_id` and `title_id` are aliases, one must be set
 
 ```ts
@@ -136,6 +145,7 @@ type CTRCryptoOptions = {
 	release_date: bigint;
 	content_datatype: number;
 	ns_data_id: number;
+	version: number;
 }
 ```
 

--- a/src/3ds.ts
+++ b/src/3ds.ts
@@ -27,7 +27,7 @@ export type CTRCryptoOptions = {
 	content_datatype: number;
 	ns_data_id: number;
 	version: number;
-	path_or_buffer?: string | Buffer; // * Not needed in boss.encrypt()
+	content?: string | Buffer; // * Not needed in boss.encrypt()
 }
 
 const BOSS_CTR_VER = 0x10001;
@@ -160,10 +160,10 @@ export function encrypt3DS(aesKey: string | Buffer, serialNumber: bigint, option
 	const payloadCount = options.length;
 	let payloadContents: Buffer = Buffer.alloc(0);
 	options.forEach((option: CTRCryptoOptions) => {
-		if (typeof option.path_or_buffer === 'undefined') {
+		if (typeof option.content === 'undefined') {
 			throw new Error('No path_or_buffer set');
 		}
-		const content = getDataFromPathOrBuffer(option.path_or_buffer);
+		const content = getDataFromPathOrBuffer(option.content);
 
 		let programID: string | number | bigint;
 

--- a/src/3ds.ts
+++ b/src/3ds.ts
@@ -13,8 +13,7 @@ export type CTRPayloadContent = {
 
 export type CTRBOSSContainer = {
 	hash_type: number;
-	// TODO - This isn't a release date! See https://www.3dbrew.org/wiki/SpotPass#BOSS_Header
-	release_date: bigint;
+	serial_number: bigint;
 	iv: Buffer;
 	content_header_hash: Buffer;
 	content_header_hash_signature: Buffer;
@@ -24,11 +23,11 @@ export type CTRBOSSContainer = {
 export type CTRCryptoOptions = {
 	program_id?: string | number | bigint; // * Program ID and title ID are aliases
 	title_id?: string | number | bigint;   // * Program ID and title ID are aliases
-	// TODO - This isn't a release date! See https://www.3dbrew.org/wiki/SpotPass#BOSS_Header
-	release_date: bigint;
+	serial_number?: bigint; // * Only used in boss.encrypt()
 	content_datatype: number;
 	ns_data_id: number;
 	version: number;
+	path_or_buffer?: string | Buffer; // * Not needed in boss.encrypt()
 }
 
 const BOSS_CTR_VER = 0x10001;
@@ -51,7 +50,7 @@ export function decrypt3DS(pathOrBuffer: string | Buffer, aesKey: string | Buffe
 
 	verifyKey(aesKey);
 
-	// PARSE THE BOSS DATA HEADER
+	// * Parse the BOSS data header
 	const data = getDataFromPathOrBuffer(pathOrBuffer);
 
 	const hashType = data.readUInt16BE(0x18);
@@ -60,19 +59,19 @@ export function decrypt3DS(pathOrBuffer: string | Buffer, aesKey: string | Buffe
 		throw new Error('Unknown hash type');
 	}
 
-	const releaseDate = data.readBigUInt64BE(0xC);
+	const serialNumber = data.readBigUInt64BE(0xC);
 
 	const IV = Buffer.concat([
 		data.subarray(0x1C, 0x28),
 		Buffer.from('\x00\x00\x00\x01')
 	]);
 
-	// DECRYPT BOSS CONTENT
+	// * Decrypt BOSS content
 	const decipher = crypto.createDecipheriv('aes-128-ctr', aesKey, IV);
 
 	const decryptedContent = Buffer.concat([decipher.update(data.subarray(0x28)), decipher.final()]);
 
-	// PARSE CONTENT HEADER
+	// * Parse content header
 	const contentHeader = decryptedContent.subarray(0, 0x132);
 	const contentHeaderMagic = contentHeader.subarray(0, 0x10);
 
@@ -82,7 +81,6 @@ export function decrypt3DS(pathOrBuffer: string | Buffer, aesKey: string | Buffe
 	}
 
 	const payloadsCount = contentHeader.readUInt16BE(0x10);
-
 	const contentHeaderHash = contentHeader.subarray(0x12, 0x32);
 	const contentHeaderHashSignature = contentHeader.subarray(0x32, 0x132);
 
@@ -100,7 +98,7 @@ export function decrypt3DS(pathOrBuffer: string | Buffer, aesKey: string | Buffe
 	const payloadContents = decryptedContent.subarray(0x132);
 	let payloadContentsOffset = 0;
 	for (let i = 0; i < payloadsCount; i++) {
-		// * PARSE THE PAYLOAD CONTENT HEADER
+		// * Parse the payload content header
 		const payloadContentHeader = payloadContents.subarray(payloadContentsOffset, payloadContentsOffset + 0x13C);
 		const programID = payloadContentHeader.readBigUInt64LE(); // * This is the app title ID, the wiki calls it the "program ID"
 		const contentDataType = payloadContentHeader.readUInt32BE(0xC);
@@ -140,13 +138,11 @@ export function decrypt3DS(pathOrBuffer: string | Buffer, aesKey: string | Buffe
 		payloadContentsOffset += 0x13C + contentLength;
 	}
 
-
-
 	// * We don't do any RSA signature verification because we don't have the public key
 
 	return {
 		hash_type: hashType,
-		release_date: releaseDate,
+		serial_number: serialNumber,
 		iv: IV,
 		content_header_hash: contentHeaderHash,
 		content_header_hash_signature: contentHeaderHashSignature,
@@ -154,37 +150,71 @@ export function decrypt3DS(pathOrBuffer: string | Buffer, aesKey: string | Buffe
 	};
 }
 
-export function encrypt3DS(pathOrBuffer: string | Buffer, aesKey: string | Buffer, options: CTRCryptoOptions): Buffer {
+export function encrypt3DS(aesKey: string | Buffer, serialNumber: bigint, options: CTRCryptoOptions[]): Buffer {
 	if (typeof aesKey === 'string') {
 		aesKey = Buffer.from(aesKey, 'hex');
 	}
 
 	verifyKey(aesKey);
 
-	const content = getDataFromPathOrBuffer(pathOrBuffer);
+	const payloadCount = options.length;
+	let payloadContents: Buffer = Buffer.alloc(0);
+	options.forEach((option: CTRCryptoOptions) => {
+		if (typeof option.path_or_buffer === 'undefined') {
+			throw new Error('No path_or_buffer set');
+		}
+		const content = getDataFromPathOrBuffer(option.path_or_buffer);
 
-	let programID: string | number | bigint;
+		let programID: string | number | bigint;
 
-	if (options.program_id) {
-		programID = options.program_id;
-	} else if (options.title_id) {
-		programID = options.title_id;
-	} else {
-		throw new Error('No program ID set. Set options.program_id or options.title_id');
-	}
+		if (option.program_id) {
+			programID = option.program_id;
+		} else if (option.title_id) {
+			programID = option.title_id;
+		} else {
+			throw new Error('No program ID set. Set options.program_id or options.title_id');
+		}
 
-	if (typeof programID === 'string') {
-		programID = BigInt(parseInt(programID, 16));
-	}
+		if (typeof programID === 'string') {
+			programID = BigInt(parseInt(programID, 16));
+		}
 
-	if (typeof programID === 'number') {
-		programID = BigInt(programID);
-	}
+		if (typeof programID === 'number') {
+			programID = BigInt(programID);
+		}
+
+		let payloadContentHeader = Buffer.alloc(0x1C);
+
+		payloadContentHeader.writeBigUInt64BE(programID);
+		payloadContentHeader.writeUInt32BE(option.content_datatype, 0xC);
+		payloadContentHeader.writeUInt32BE(content.length, 0x10);
+		payloadContentHeader.writeUInt32BE(option.ns_data_id, 0x14);
+		payloadContentHeader.writeUInt32BE(option.version, 0x18);
+
+		const payloadContentHeaderHashedData = Buffer.concat([
+			payloadContentHeader,
+			Buffer.from('\x00\x00'),
+			content
+		]);
+		const payloadContentHeaderHash = crypto.createHash('sha256').update(payloadContentHeaderHashedData).digest();
+
+		payloadContentHeader = Buffer.concat([
+			payloadContentHeader,
+			payloadContentHeaderHash,
+			Buffer.alloc(0x100) /// * RSA signature of the previous hash. We don't have the keys
+		]);
+
+		payloadContents = Buffer.concat([
+			payloadContents,
+			payloadContentHeader,
+			content
+		]);
+	});
 
 	let contentHeader = Buffer.alloc(0x12);
 
 	CONTENT_HEADER_MAGIC.copy(contentHeader, 0);
-	contentHeader.writeUInt16BE(0x1, 0x10); // * Payload contents count
+	contentHeader.writeUInt16BE(payloadCount, 0x10); // * Payload contents count
 
 	const contentHeaderHashedData = Buffer.concat([
 		contentHeader,
@@ -198,31 +228,9 @@ export function encrypt3DS(pathOrBuffer: string | Buffer, aesKey: string | Buffe
 		Buffer.alloc(0x100) // * RSA signature of the previous hash. We don't have the keys
 	]);
 
-	let payloadContentHeader = Buffer.alloc(0x1C);
-
-	payloadContentHeader.writeBigUInt64BE(programID);
-	payloadContentHeader.writeUInt32BE(options.content_datatype, 0xC);
-	payloadContentHeader.writeUInt32BE(content.length, 0x10);
-	payloadContentHeader.writeUInt32BE(options.ns_data_id, 0x14);
-	payloadContentHeader.writeUInt32BE(options.version, 0x18);
-
-	const payloadContentHeaderHashedData = Buffer.concat([
-		payloadContentHeader,
-		Buffer.from('\x00\x00'),
-		content
-	]);
-	const payloadContentHeaderHash = crypto.createHash('sha256').update(payloadContentHeaderHashedData).digest();
-
-	payloadContentHeader = Buffer.concat([
-		payloadContentHeader,
-		payloadContentHeaderHash,
-		Buffer.alloc(0x100) /// * RSA signature of the previous hash. We don't have the keys
-	]);
-
 	const container = Buffer.concat([
 		contentHeader,
-		payloadContentHeader,
-		content
+		payloadContents
 	]);
 
 	const IV = process.env.NODE_ENV === 'test' ? Buffer.alloc(12) : crypto.randomBytes(12);
@@ -233,7 +241,7 @@ export function encrypt3DS(pathOrBuffer: string | Buffer, aesKey: string | Buffe
 	header.write('boss', 0);
 	header.writeUInt32BE(BOSS_CTR_VER, 0x4);
 	header.writeUInt32BE(header.length + container.length, 0x8); // * Total BOSS file size. Decrypted and encrypted lengths are the same
-	header.writeBigUInt64BE(options.release_date, 0xC);
+	header.writeBigUInt64BE(serialNumber, 0xC);
 	header.writeUInt16BE(1, 0x14); // * Always 1
 	// * Skip 2 bytes of padding
 	header.writeUInt16BE(2, 0x18); // * Hash type. 2 = SHA-256

--- a/src/3ds.ts
+++ b/src/3ds.ts
@@ -161,7 +161,7 @@ export function encrypt3DS(aesKey: string | Buffer, serialNumber: bigint, option
 	let payloadContents: Buffer = Buffer.alloc(0);
 	options.forEach((option: CTRCryptoOptions) => {
 		if (typeof option.content === 'undefined') {
-			throw new Error('No path_or_buffer set');
+			throw new Error('No content was set');
 		}
 		const content = getDataFromPathOrBuffer(option.content);
 

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -25,7 +25,12 @@ export function encrypt(pathOrBuffer: string | Buffer, version: number, aesKey: 
 			throw new Error('Invalid CTRCryptoOptions');
 		}
 
-		return encrypt3DS(data, aesKey, hmacKeyOrOptions);
+		if (typeof hmacKeyOrOptions.serial_number === 'undefined') {
+			throw new Error('Serial number is undefined');
+		}
+
+		hmacKeyOrOptions.path_or_buffer = data;
+		return encrypt3DS(aesKey, hmacKeyOrOptions.serial_number, [hmacKeyOrOptions]);
 	} else {
 		throw new Error('Unknown version');
 	}

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -29,7 +29,7 @@ export function encrypt(pathOrBuffer: string | Buffer, version: number, aesKey: 
 			throw new Error('Serial number is undefined');
 		}
 
-		hmacKeyOrOptions.path_or_buffer = data;
+		hmacKeyOrOptions.content = data;
 		return encrypt3DS(aesKey, hmacKeyOrOptions.serial_number, [hmacKeyOrOptions]);
 	} else {
 		throw new Error('Unknown version');

--- a/tests/3ds/decrypt.js
+++ b/tests/3ds/decrypt.js
@@ -7,7 +7,7 @@ const { BOSS_3DS_AES_KEY } = process.env;
 
 const expected = {
 	hash_type: 2,
-	release_date: 1692231927n,
+	serial_number: 1692231927n,
 	iv: Buffer.from('00000000000000000000000000000001', 'hex'),
 	content_header_hash: Buffer.from('5cd5d8198b7ce64edc796c147f333a76c3714269066504c9232f28cabe4306db', 'hex'),
 	content_header_hash_signature: Buffer.from('00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', 'hex'),
@@ -69,7 +69,7 @@ const encrypted = Buffer.from([
 const decrypted = decrypt3DS(encrypted, BOSS_3DS_AES_KEY);
 
 assert.equal(decrypted.hash_type, expected.hash_type, `Decrypted hash type does not match. Expected ${expected.hash_type}. Got ${decrypted.hash_type}`);
-assert.equal(decrypted.release_date, expected.release_date, `Decrypted release date does not match. Expected ${expected.release_date}. Got ${decrypted.release_date}`);
+assert.equal(decrypted.serial_number, expected.serial_number, `Decrypted serial number does not match. Expected ${expected.serial_number}. Got ${decrypted.serial_number}`);
 assert.ok(expected.iv.equals(decrypted.iv), `Invalid IV. Expected\n\n${expected.iv.toString('hex')}\n\nGot\n\n${decrypted.iv.toString('hex')}`);
 assert.ok(expected.content_header_hash.equals(decrypted.content_header_hash), `Invalid content header hash. Expected\n\n${expected.content_header_hash.toString('hex')}\n\nGot\n\n${decrypted.content_header_hash.toString('hex')}`);
 assert.ok(expected.content_header_hash_signature.equals(decrypted.content_header_hash_signature), `Invalid content header hash signature. Expected\n\n${expected.content_header_hash_signature.toString('hex')}\n\nGot\n\n${decrypted.content_header_hash_signature.toString('hex')}`);

--- a/tests/3ds/decrypt.js
+++ b/tests/3ds/decrypt.js
@@ -11,6 +11,7 @@ const expected = {
 	iv: Buffer.from('00000000000000000000000000000001', 'hex'),
 	content_header_hash: Buffer.from('5cd5d8198b7ce64edc796c147f333a76c3714269066504c9232f28cabe4306db', 'hex'),
 	content_header_hash_signature: Buffer.from('00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', 'hex'),
+	payload_contents_length: 1,
 	payload_content_header_hash: Buffer.from('e3403f8fcd420e9fa3e8524779edfa5b08ba316be5d377e42e71e6cdcdf03207', 'hex'),
 	payload_content_header_hash_signature: Buffer.from('00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', 'hex'),
 	program_id: 11542673336828928n,
@@ -72,9 +73,13 @@ assert.equal(decrypted.release_date, expected.release_date, `Decrypted release d
 assert.ok(expected.iv.equals(decrypted.iv), `Invalid IV. Expected\n\n${expected.iv.toString('hex')}\n\nGot\n\n${decrypted.iv.toString('hex')}`);
 assert.ok(expected.content_header_hash.equals(decrypted.content_header_hash), `Invalid content header hash. Expected\n\n${expected.content_header_hash.toString('hex')}\n\nGot\n\n${decrypted.content_header_hash.toString('hex')}`);
 assert.ok(expected.content_header_hash_signature.equals(decrypted.content_header_hash_signature), `Invalid content header hash signature. Expected\n\n${expected.content_header_hash_signature.toString('hex')}\n\nGot\n\n${decrypted.content_header_hash_signature.toString('hex')}`);
-assert.ok(expected.payload_content_header_hash.equals(decrypted.payload_content_header_hash), `Invalid payload header hash. Expected\n\n${expected.payload_content_header_hash.toString('hex')}\n\nGot\n\n${decrypted.payload_content_header_hash.toString('hex')}`);
-assert.ok(expected.payload_content_header_hash_signature.equals(decrypted.payload_content_header_hash_signature), `Invalid payload header hash signature. Expected\n\n${expected.payload_content_header_hash_signature.toString('hex')}\n\nGot\n\n${decrypted.payload_content_header_hash_signature.toString('hex')}`);
-assert.equal(decrypted.program_id, expected.program_id, `Decrypted program (title) ID does not match. Expected ${expected.program_id}. Got ${decrypted.program_id}`);
-assert.equal(decrypted.content_datatype, expected.content_datatype, `Decrypted data type does not match. Expected ${expected.content_datatype}. Got ${decrypted.content_datatype}`);
-assert.equal(decrypted.ns_data_id, expected.ns_data_id, `Decrypted NS data ID does not match. Expected ${expected.ns_data_id}. Got ${decrypted.ns_data_id}`);
-assert.ok(expected.content.equals(decrypted.content), `Invalid decrypted content. Expected\n\n${expected.content.toString('hex')}\n\nGot\n\n${decrypted.content.toString('hex')}`);
+assert.equal(decrypted.payload_contents.length, expected.payload_contents_length, `Invalid payload contents length. Expected\n\n${expected.payload_contents_length}\n\nGot\n\n${decrypted.payload_contents.length}`);
+
+const payload = decrypted.payload_contents[0];
+
+assert.ok(expected.payload_content_header_hash.equals(payload.payload_content_header_hash), `Invalid payload header hash. Expected\n\n${expected.payload_content_header_hash.toString('hex')}\n\nGot\n\n${payload.payload_content_header_hash.toString('hex')}`);
+assert.ok(expected.payload_content_header_hash_signature.equals(payload.payload_content_header_hash_signature), `Invalid payload header hash signature. Expected\n\n${expected.payload_content_header_hash_signature.toString('hex')}\n\nGot\n\n${payload.payload_content_header_hash_signature.toString('hex')}`);
+assert.equal(payload.program_id, expected.program_id, `Decrypted program (title) ID does not match. Expected ${expected.program_id}. Got ${payload.program_id}`);
+assert.equal(payload.content_datatype, expected.content_datatype, `Decrypted data type does not match. Expected ${expected.content_datatype}. Got ${payload.content_datatype}`);
+assert.equal(payload.ns_data_id, expected.ns_data_id, `Decrypted NS data ID does not match. Expected ${expected.ns_data_id}. Got ${payload.ns_data_id}`);
+assert.ok(expected.content.equals(payload.content), `Invalid decrypted content. Expected\n\n${expected.content.toString('hex')}\n\nGot\n\n${payload.content.toString('hex')}`);

--- a/tests/3ds/encrypt.js
+++ b/tests/3ds/encrypt.js
@@ -57,7 +57,7 @@ const encrypted = encrypt3DS(BOSS_3DS_AES_KEY, 1692231927n, [{
 	content_datatype: 65537,
 	ns_data_id: 36,
 	version: 1,
-	path_or_buffer: content,
+	content,
 }]);
 
 assert.ok(expected.equals(encrypted), `Invalid encrypted data. Expected\n\n${expected.toString('hex')}\n\nGot\n\n${encrypted.toString('hex')}`);

--- a/tests/3ds/encrypt.js
+++ b/tests/3ds/encrypt.js
@@ -52,12 +52,12 @@ const expected = Buffer.from([
 ]);
 
 const content = Buffer.from('Hello World');
-const encrypted = encrypt3DS(content, BOSS_3DS_AES_KEY, {
+const encrypted = encrypt3DS(BOSS_3DS_AES_KEY, 1692231927n, [{
 	program_id: 0x0004001000022900, // can also be named "title_id"
 	content_datatype: 65537,
-	release_date: 1692231927n,
 	ns_data_id: 36,
 	version: 1,
-});
+	path_or_buffer: content,
+}]);
 
 assert.ok(expected.equals(encrypted), `Invalid encrypted data. Expected\n\n${expected.toString('hex')}\n\nGot\n\n${encrypted.toString('hex')}`);

--- a/tests/3ds/encrypt.js
+++ b/tests/3ds/encrypt.js
@@ -57,6 +57,7 @@ const encrypted = encrypt3DS(content, BOSS_3DS_AES_KEY, {
 	content_datatype: 65537,
 	release_date: 1692231927n,
 	ns_data_id: 36,
+	version: 1,
 });
 
 assert.ok(expected.equals(encrypted), `Invalid encrypted data. Expected\n\n${expected.toString('hex')}\n\nGot\n\n${encrypted.toString('hex')}`);


### PR DESCRIPTION
A BOSS container may have multiple payload contents, or even none in some cases where they aren't used. Add an array of payload contents to the CTRBOSSContainer to address this. Credits to 3dbrew user Meleemeister for the initial discovery

Add version field to payload content aswell.